### PR TITLE
Add framework extras

### DIFF
--- a/layouts/default.htm
+++ b/layouts/default.htm
@@ -35,8 +35,9 @@ description = "Default layout"
         <script type="text/javascript" src="{{ 'assets/js/manifest.js'|theme }}"></script>
         <script type="text/javascript" src="{{ 'assets/js/vendor.js'|theme }}"></script>
         <script type="text/javascript" src="{{ 'assets/js/app.js'|theme }}"></script>
-
+        {% framework extras %}
         {% scripts %}
+        
     </body>
 
 </html>


### PR DESCRIPTION
Some of the octobercms features depend on the ajax framework so it would be nice to have it included by default in the starter theme